### PR TITLE
Moved signalQuality under info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10227,9 +10227,9 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -11690,9 +11690,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "dsp.js": "^1.0.1",
     "fili": "^2.0.1",
-    "rxjs": "^6.3.1"
+    "rxjs": "^6.6.3"
   },
   "devDependencies": {
     "@types/node": "^10.12.10",

--- a/src/pipes/utility/addSignalQuality.ts
+++ b/src/pipes/utility/addSignalQuality.ts
@@ -21,13 +21,16 @@ export const addSignalQuality = ({ dataProp = defaultDataProp } = {}) =>
         : epoch[dataProp].map((_, i) => i);
       return {
         ...epoch,
-        signalQuality: epoch[dataProp].reduce(
-          (acc, curr, index) => ({
-            ...acc,
-            [names[index]]: standardDeviation(curr)
-          }),
-          {}
-        )
+        info: {
+          ...epoch.info,
+          signalQuality: epoch[dataProp].reduce(
+            (acc, curr, index) => ({
+              ...acc,
+              [names[index]]: standardDeviation(curr)
+            }),
+            {}
+          )  
+        }
       };
     })
   );


### PR DESCRIPTION
Pipes such as fft only forward the info object. Moving the signalQuality object under info so it is preserved.